### PR TITLE
Comment out CI tests that need ephemeral-cluster

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,81 +75,84 @@ jobs:
           make test-import
         if: env.GIT_DIFF
 
-  test-solidity:
-    runs-on: ubuntu-latest
-    timeout-minutes: 240
-    strategy:
-      fail-fast: false
-      matrix:
-        batch: ['1-3', '2-3', '3-3']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - uses: technote-space/get-diff-action@v6.0.1
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.sol
-            **/**.go
-            tests/solidity/**/*.js
-            tests/solidity/**/*.sh
-            go.mod
-            go.sum
-      - name: test-solidity
-        run: |
-          ./scripts/run-solidity-tests.sh --batch=${{ matrix.batch }}
-        if: env.GIT_DIFF
+  # TODO(jbowen93): https://github.com/celestiaorg/ethermint/issues/25
+  # test-solidity:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 240
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       batch: ['1-3', '2-3', '3-3']
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-go@v2
+  #       with:
+  #         go-version: 1.17
+  #     - uses: technote-space/get-diff-action@v6.0.1
+  #       id: git_diff
+  #       with:
+  #         PATTERNS: |
+  #           **/**.sol
+  #           **/**.go
+  #           tests/solidity/**/*.js
+  #           tests/solidity/**/*.sh
+  #           go.mod
+  #           go.sum
+  #     - name: test-solidity
+  #       run: |
+  #         ./scripts/run-solidity-tests.sh --batch=${{ matrix.batch }}
+  #       if: env.GIT_DIFF
 
-  liveness-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2.1.4
-        with:
-          go-version: 1.17
-      - uses: technote-space/get-diff-action@v6.0.1
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
-      - name: Install Starport
-        run: |
-          curl https://get.starport.network/starport! | bash
-        if: env.GIT_DIFF
-      - name: Start Local Network via Starport
-        run: |
-          starport chain serve --reset-once -v -c ./starport.yml > starport.out 2>&1 &
-        if: env.GIT_DIFF
-      - name: Test Local Network Liveness
-        run: |
-          sleep 2m
-          ./contrib/scripts/test_localnet_liveness.sh 100 5 50 localhost
-        if: env.GIT_DIFF
+  # TODO(jbowen93): https://github.com/celestiaorg/ethermint/issues/26
+  # liveness-test:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-go@v2.1.4
+  #       with:
+  #         go-version: 1.17
+  #     - uses: technote-space/get-diff-action@v6.0.1
+  #       id: git_diff
+  #       with:
+  #         PATTERNS: |
+  #           **/**.go
+  #           go.mod
+  #           go.sum
+  #     - name: Install Starport
+  #       run: |
+  #         curl https://get.starport.network/starport! | bash
+  #       if: env.GIT_DIFF
+  #     - name: Start Local Network via Starport
+  #       run: |
+  #         starport chain serve --reset-once -v -c ./starport.yml > starport.out 2>&1 &
+  #       if: env.GIT_DIFF
+  #     - name: Test Local Network Liveness
+  #       run: |
+  #         sleep 2m
+  #         ./contrib/scripts/test_localnet_liveness.sh 100 5 50 localhost
+  #       if: env.GIT_DIFF
       
-  test-rpc:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/setup-go@v2.1.4
-        with:
-          go-version: 1.17
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
-        with:
-          PATTERNS: |
-            **/**.sol
-            **/**.go
-            go.mod
-            go.sum
-      - name: Test rpc endpoint
-        run: |
-          make test-rpc
-        if: env.GIT_DIFF
+  # TODO(jbowen93): https://github.com/celestiaorg/ethermint/issues/27
+  # test-rpc:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   steps:
+  #     - uses: actions/setup-go@v2.1.4
+  #       with:
+  #         go-version: 1.17
+  #     - uses: actions/checkout@v3
+  #     - uses: technote-space/get-diff-action@v6.0.1
+  #       with:
+  #         PATTERNS: |
+  #           **/**.sol
+  #           **/**.go
+  #           go.mod
+  #           go.sum
+  #     - name: Test rpc endpoint
+  #       run: |
+  #         make test-rpc
+  #       if: env.GIT_DIFF
 
   test-e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR comments out the existing CI tests that don't work due to our reliance on a DA layer. This will be re added when we integrate them with the [ephemeral-cluster](https://github.com/celestiaorg/ephemeral-cluster).

Resolves: https://github.com/celestiaorg/ethermint/issues/21

New Tracking Issues:
- #25
- #26
- #27
