### PR TITLE
add verbose flag to go tests run

### DIFF
--- a/.github/workflows/build-test-evmos.yml
+++ b/.github/workflows/build-test-evmos.yml
@@ -105,4 +105,5 @@ jobs:
         echo "------------- docker logs evmos0 -------------"
         docker logs evmos0
         cd /home/runner/work/ethermint/ethermint
-        MODE=rpc HOST=http://127.0.0.1:8545 go test ./tests/rpc/...
+        echo "------------- go test ./tests/rpc/... -------------"
+        MODE=rpc HOST=http://127.0.0.1:8545 go test ./tests/rpc/... -v


### PR DESCRIPTION
This PR adds a verbose flag to the evmos build and test gh action when running the ethermint rpc tests