### PR TITLE
Update GH actions to work with Ethermint images

### DIFF
--- a/.github/workflows/docker-build-debug.yml
+++ b/.github/workflows/docker-build-debug.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    if: ! github.event.pull_request.head.repo.fork
+    if: "! github.event.pull_request.head.repo.fork"
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 

--- a/.github/workflows/docker-build-debug.yml
+++ b/.github/workflows/docker-build-debug.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    if: "! github.event.pull_request.head.repo.fork"
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 

--- a/.github/workflows/docker-build-debug.yml
+++ b/.github/workflows/docker-build-debug.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    if: ! github.event.pull_request.head.repo.fork
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 
@@ -28,7 +29,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,suffix=-ethermint-debug
+            type=sha,suffix=-debug
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    if: ! github.event.pull_request.head.repo.fork
+    if: "! github.event.pull_request.head.repo.fork"
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 
@@ -54,7 +54,7 @@ jobs:
           file: docker/Dockerfile
 
   test:
-    if: ! github.event.pull_request.head.repo.fork
+    if: "! github.event.pull_request.head.repo.fork"
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -11,8 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: celestiaorg/evmos
-  TAG_PREFIX: ethermint-
+  IMAGE_NAME: celestiaorg/ethermint
 
 jobs:
   build:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=${{ env.TAG_PREFIX }}
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -72,7 +72,7 @@ jobs:
         go-version: 1.17
     - name: "Setup Cluster"
       run: |
-        export ETHERMINT_IMAGE_TAG=ethermint-$(git rev-parse --short "$GITHUB_SHA")
+        export ETHERMINT_IMAGE_TAG=sha-$(git rev-parse --short "$GITHUB_SHA")
         echo $ETHERMINT_IMAGE_TAG
         cd ephemeral-cluster
         scripts/minimal-astria.sh

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    if: "! github.event.pull_request.head.repo.fork"
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 
@@ -54,7 +54,7 @@ jobs:
           file: docker/Dockerfile
 
   test:
-    if: "! github.event.pull_request.head.repo.fork"
+    if: github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: ! github.event.pull_request.head.repo.fork
     runs-on: "ubuntu-latest"
     permissions:
       contents: write 
@@ -53,6 +54,7 @@ jobs:
           file: docker/Dockerfile
 
   test:
+    if: ! github.event.pull_request.head.repo.fork
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -70,10 +72,10 @@ jobs:
         go-version: 1.17
     - name: "Setup Cluster"
       run: |
-        export EVMOS_IMAGE_TAG=ethermint-$(git rev-parse --short "$GITHUB_SHA")
-        echo $EVMOS_IMAGE_TAG
+        export ETHERMINT_IMAGE_TAG=ethermint-$(git rev-parse --short "$GITHUB_SHA")
+        echo $ETHERMINT_IMAGE_TAG
         cd ephemeral-cluster
-        scripts/minimal-cevmos.sh
+        scripts/minimal-astria.sh
     - name: "Test Cluster"
       run: | 
         docker ps -a

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -74,7 +74,7 @@ jobs:
         export ETHERMINT_IMAGE_TAG=sha-$(git rev-parse --short "$GITHUB_SHA")
         echo $ETHERMINT_IMAGE_TAG
         cd ephemeral-cluster
-        scripts/minimal-astria.sh
+        scripts/minimal-ethermint.sh
     - name: "Test Cluster"
       run: | 
         docker ps -a
@@ -86,8 +86,8 @@ jobs:
         docker logs light0
         echo "------------- docker logs dalc0 -------------"
         docker logs dalc0
-        echo "------------- docker logs evmos0 -------------"
-        docker logs evmos0
+        echo "------------- docker logs ethermint0 -------------"
+        docker logs ethermint0
         cd /home/runner/work/ethermint/ethermint
         echo "------------- go test ./tests/rpc/... -------------"
         MODE=rpc HOST=http://127.0.0.1:8545 go test ./tests/rpc/... -v

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=build-env /src/build/ethermintd /usr/bin/ethermintd
 EXPOSE 26656 26657
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["evmosd"]
+CMD ["ethermintd"]

--- a/docker/debug.Dockerfile
+++ b/docker/debug.Dockerfile
@@ -10,15 +10,11 @@ ENV COSMOS_BUILD_OPTIONS nostrip
 # Set working directory for the build
 WORKDIR /src 
 
-COPY go.mod go.sum ./
-RUN go mod download
 COPY . .
+RUN go mod download
 
 # Build Delve
 RUN env GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/go-delve/delve/cmd/dlv@latest
-
-# Add source files
-COPY . .
 
 # Make the binary
 RUN env GOOS=$TARGETOS GOARCH=$TARGETARCH make build 


### PR DESCRIPTION
This relies on the `ethermint` branch of ephemeral-cluster (https://github.com/celestiaorg/ephemeral-cluster/pull/16)

There will need to be a follow up PR after the above PR is merged to pull ephemeral-cluster from `main` branch not `ethermint`. 