### PR TITLE
Automatic debug image builds use distinct image name not tag

### DIFF
--- a/.github/workflows/docker-build-debug.yml
+++ b/.github/workflows/docker-build-debug.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}-debug
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,suffix=-debug
+            type=sha
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: celestiaorg/ethermint
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:


### PR DESCRIPTION
Modify the Github actions so that when building a debug image (that is, one wrapped in dlv) a distinct image name `ethermint-debug` is used instead of just adding a `-debug` suffix to the tag. This will prevent a debug image ever accidentally slipping into `latest`. 