### PR TITLE
use main branch of ephemeral-cluster in tests

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -64,7 +64,6 @@ jobs:
       with:
         repository: celestiaorg/ephemeral-cluster
         path: ephemeral-cluster
-        ref: ethermint
     - name: Set up Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
Needed as https://github.com/celestiaorg/ephemeral-cluster/pull/16 removed the `ethermint` branch